### PR TITLE
Remove scan API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Blockchain Analyzer is a proof of concept for monitoring blockchain activity and
 * Watchlists for addresses or contracts
 * Alerts through Discord, Telegram or email
 * FastAPI based web dashboard
+* Works entirely via RPC/Web3 without the need for external scan APIs
 
 ## Installation
 
@@ -22,15 +23,13 @@ pip install -r requirements.txt
 
 ## Configuration
 
-All settings live in `blockchain_analyzer/module_config.yaml`. Update RPC endpoints, API keys and alert channels to match your environment. Below is a shortened example:
+All settings live in `blockchain_analyzer/module_config.yaml`. Update RPC endpoints and alert channels to match your environment. Below is a shortened example:
 
 ```yaml
 blockchains:
   ethereum:
     rpc_endpoints:
       - "https://mainnet.infura.io/v3/YOUR_API_KEY"
-    scan_api: "https://api.etherscan.io/api"
-    scan_api_key: "YOUR_ETHERSCAN_KEY"
     chain_id: 1
 alerts:
   discord_webhook: ""

--- a/blockchain_analyzer/module_config.yaml
+++ b/blockchain_analyzer/module_config.yaml
@@ -2,8 +2,6 @@ blockchains:
   ethereum:
     rpc_endpoints:
       - "https://mainnet.infura.io/v3/YOUR_API_KEY"
-    scan_api: "https://api.etherscan.io/api"
-    scan_api_key: "YOUR_ETHERSCAN_KEY"
     chain_id: 1
     priority: 1
     enabled: true


### PR DESCRIPTION
## Summary
- drop `scan_api` and `scan_api_key` from module config
- rely on RPC-only ABI detection
- replace scan API calls in `MemeCoinTracker` with block/transaction scans
- document RPC-only requirement

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6848e970129c8320ac1897aa57ffde7f